### PR TITLE
Improving contributing docs/process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to Takahē
+
+## Getting Started
+
+Takahē requires Python 3.11
+
+Create and activate a virtual environment
+
+```
+python3 -m venv .venv
+. .venv/bin/activate
+```
+
+Install the development requirements:
+
+```
+pip install -r requirements-dev.txt
+```
+
+Enable git commit hooks:
+
+```bash
+pre-commit install
+```
+
+Try running the tests:
+
+```bash
+pytest
+```
+
+# Code of Conduct
+
+As a contributor, you can help us keep the Takahē community open and inclusive. Takahē
+follows the [Django Project Code of Conduct](https://www.djangoproject.com/conduct/).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+Copyright 2022 Andrew Godwin
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,16 @@ Goals:
 * Multiple account domains possible per server
 * Mastodon client API compatible
 * Async evented core for fan-out/delivery
+
+
+## Deployment
+
+### Requirements:
+
+- **Python** 3.11
+- **Postgresql** 14+
+- **Lots of patience** This is *very experimental*
+
+## Contributing
+
+If you'd like to contribute, please read [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/manage.py
+++ b/manage.py
@@ -3,10 +3,26 @@
 import os
 import sys
 
+# List of settings files that should guard against running certain commands
+GUARDED_ENVIRONMENTS = [
+    "production",
+]
+
+GUARDED_COMMANDS =[
+    "test",
+]
+
 
 def main():
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "takahe.settings.production")
+
+    # Guard against running tests in arbitrary environments
+    env_name = os.environ["DJANGO_SETTINGS_MODULE"].rsplit(".", 1)[-1]
+    if env_name in GUARDED_ENVIRONMENTS:
+        for cmd in sys.argv:
+            if cmd in GUARDED_COMMANDS:
+                raise Exception(f"Cannot run {cmd} in {env_name}")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+pre-commit~=2.20.0
+-r requirements.txt
+black==22.10.0
+flake8==5.0.4
+isort==5.10.1
+pre-commit~=2.20.0
+pytest-django~=4.5.2
+pytest-httpx~=0.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,4 @@ uvicorn~=0.19
 gunicorn~=20.1.0
 psycopg2~=2.9.5
 bleach~=5.0.1
-pytest-django~=4.5.2
-pytest-httpx~=0.21
 pydantic~=1.10.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-exclude = venv/*,tox/*,specs/*
+exclude = .venv/*,venv/*,tox/*,specs/*
 ignore = E123,E128,E203,E266,E402,F405,E501,W503,E731,W601
 max-line-length = 119
 

--- a/takahe/settings/base.py
+++ b/takahe/settings/base.py
@@ -55,6 +55,7 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql_psycopg2",
         "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
+        "PORT": os.environ.get("POSTGRES_PORT", 5432),
         "NAME": os.environ.get("POSTGRES_DB", "takahe"),
         "USER": os.environ.get("POSTGRES_USER", "postgres"),
         "PASSWORD": os.environ.get("POSTGRES_PASSWORD"),

--- a/takahe/settings/development.py
+++ b/takahe/settings/development.py
@@ -11,3 +11,9 @@ MIDDLEWARE.insert(0, "core.middleware.AlwaysSecureMiddleware")
 # Ensure debug features are on
 DEBUG = True
 CRISPY_FAIL_SILENTLY = False
+
+ALLOWED_HOSTS = ["*"]
+CSRF_TRUSTED_ORIGINS = [
+    "http://127.0.0.1:8000",
+    "https://127.0.0.1:8000",
+]

--- a/users/views/identity.py
+++ b/users/views/identity.py
@@ -26,7 +26,7 @@ class ViewIdentity(TemplateView):
             fetch=True,
         )
         posts = identity.posts.all()[:100]
-        if identity.data_age > Config.load().IDENTITY_MAX_AGE:
+        if identity.data_age > Config.load().identity_max_age:
             identity.transition_perform(IdentityStates.outdated)
         return {
             "identity": identity,


### PR DESCRIPTION
* Guard against running tests with production settings
* Add BSD-3 license
* Document from zero to pytest
* Minor changes to allow `runserver` using `takahe.settings.development`