### PR TITLE
Add .git directory to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *.psql
 *.sqlite3
 notes.md
+.git
 .venv
 .pre-commit-config.yaml


### PR DESCRIPTION
I noticed files from `.git` were incorrectly being added to the takahe Docker image when running `make`; this excludes that directory.