### PR TITLE
Add missing Debian build dependencies for Python 3 dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11.0-slim-buster
 
-RUN apt-get update && apt-get -y install libpq-dev python3-dev build-essential
+RUN apt-get update && apt-get -y install libpq-dev libxml2-dev libxslt1-dev zlib1g-dev python3-dev build-essential
 
 COPY requirements.txt requirements.txt
 


### PR DESCRIPTION
Python dependencies failed to build/install as part of the Docker image build until I added these Debian dependencies to the Dockerfile.

Was able to reproduce the issue before this change on a 2021 M1 MacBook Pro running macOS Ventura 13.0.1 and Docker Desktop 4.14.1 (91661) / Engine 20.10.21.