### PR TITLE
Document Docker development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /docs/_build
 /media/
 notes.md
+__pycache__/
+*.pyc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,32 +2,62 @@
 
 ## Getting Started
 
-Takahē requires Python 3.11
+Development can be done "bare metal" or with Docker.  We'll describe both here.
 
-Create and activate a virtual environment
 
-```
-python3 -m venv .venv
-. .venv/bin/activate
-```
+### Bare Metal
 
-Install the development requirements:
+Takahē requires Python 3.11, so you'll need that first.  Then, create and
+activate a virtual environment:
 
-```
-pip install -r requirements-dev.txt
+```shell
+$ python3 -m venv .venv
+$ . .venv/bin/activate
 ```
 
-Enable git commit hooks:
+You can install the development requirements:
+
+```shell
+$ pip install -r requirements-dev.txt
+```
+
+...and enable git commit hooks if you like:
 
 ```bash
-pre-commit install
+$ pre-commit install
 ```
 
-Try running the tests:
+Finally, you can run the tests with PyTest:
 
 ```bash
-pytest
+$ pytest
 ```
+
+
+### Docker
+
+The docker build process will take care of much of the above, but you just have
+to be sure that you're executing it from the project root.
+
+First, you need to build your image:
+
+```shell
+$ docker build -f ./docker/Dockerfile -t "takahe:latest" .
+```
+
+Then start the `compose` session:
+
+```shell
+$ docker compose -f docker/docker-compose.yml up
+```
+
+Once your session is up and running, you can run the tests inside your
+container:
+
+```shell
+$ docker compose -f docker/docker-compose.yml exec web pytest
+```
+
 
 # Code of Conduct
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       - db
     ports:
       - "8000:8000"
+    volumes:
+      - ../:/takahe/
 
 networks:
   internal_network:


### PR DESCRIPTION
While I'd argue that moving the Docker files into the project root is the more accessible option, this PR at least documents how to make use of them where they are.  See #17 for reference.

This also mounts the project root at /takahe/ to make development possible.
